### PR TITLE
feat: Use package license expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Use license expression instead of embedding LICENSE file, to work better with NuGet Gallery.
+
 ## [0.1.0-beta.0] - 2022-12-12
 
 ### Added

--- a/src/Swashbuckle.AspNetCore.HealthChecks/Swashbuckle.AspNetCore.HealthChecks.csproj
+++ b/src/Swashbuckle.AspNetCore.HealthChecks/Swashbuckle.AspNetCore.HealthChecks.csproj
@@ -24,7 +24,7 @@
         <Copyright>Copyright (c) Rich Tebb</Copyright>
         <PackageTags>swashbuckle;swagger;openapi;health-check;webapi;aspnet;aspnetcore</PackageTags>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageLicenseExpression>ISC</PackageLicenseExpression>
         <PackageProjectUrl></PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>
     </PropertyGroup>
@@ -75,7 +75,6 @@
         <Link>StyleCop.json</Link>
       </AdditionalFiles>
       <None Include="..\..\README.md" Pack="true" PackagePath="\" />
-      <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
       <None Include="icon.png" Pack="true" PackagePath="" />
     </ItemGroup>
 


### PR DESCRIPTION
An SPDX license expression works better than embedding the license text for NuGet Gallery